### PR TITLE
Fix quetz-client.json

### DIFF
--- a/version_pr_info/9/f/8/7/8/quetz-client.json
+++ b/version_pr_info/9/f/8/7/8/quetz-client.json
@@ -1,37 +1,8 @@
 {
- "bad": false,
- "new_version": "0.6.1",
- "new_version_attempts": {
-  "0.0.2": 1,
-  "0.0.3": 1,
-  "0.0.4": 1,
-  "0.1.1": 142,
-  "0.1.2": 238,
-  "0.2.0": 131,
-  "0.3.0": 144,
-  "0.4.0": 26,
-  "0.4.1": 2,
-  "0.4.2": 15,
-  "0.4.3": 6,
-  "0.4.4": 25,
-  "0.5.0": 4,
-  "0.5.1": 2,
-  "0.6.0": 2,
-  "0.6.1": 7
- },
- "new_version_errors": {
-  "0.1.1": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.1.1' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.1.2": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.1.2' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.2.0": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.2.0' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.3.0": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.3.0' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.4.0": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.4.0' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.4.1": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.4.1' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.4.2": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.4.2' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.4.3": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.4.3' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.4.4": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.4.4' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.5.0": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.5.0' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.5.1": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.5.1' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.6.0": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.6.0' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz'\n",
-  "0.6.1": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '0.6.1' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/quetz_client-{{ version }}.tar.gz'\n"
- }
+  "bad": false,
+  "new_version": "0.2.1",
+  "new_version_attempts": {
+    "0.2.1": 1
+  },
+  "new_version_errors": {}
 }


### PR DESCRIPTION
This is an attempt to fix the autotick bot failing for the quetz client feedstock.

They changed the feedstock source from `https://github.com/TheSnakePit/quetz/archive/client_v{{ version }}.tar.gz` to the PyPi `quetz-client` package.

@beckermr could you review this please?