### PR TITLE
Retry CUDA 12 migration of `hoomd-dlext`

### DIFF
--- a/status/migration_json/cuda120.json
+++ b/status/migration_json/cuda120.json
@@ -219,13 +219,6 @@
       "pr_url": "https://github.com/conda-forge/hoomd-feedstock",
       "pre_pr_migrator_status": ""
     },
-    "hoomd-dlext": {
-      "immediate_children": [],
-      "num_descendants": 0,
-      "pr_status": "",
-      "pr_url": "https://github.com/conda-forge/hoomd-dlext-feedstock",
-      "pre_pr_migrator_status": ""
-    },
     "implicit": {
       "immediate_children": [],
       "num_descendants": 0,
@@ -765,7 +758,6 @@
     "nvcomp",
     "cuda-python",
     "hoomd",
-    "hoomd-dlext",
     "colmap",
     "libastra",
     "parallelproj",


### PR DESCRIPTION
This PR was closed out instead of re-run. So `hoomd-dlext` wasn't actually migrated successfully. This requeues the `hoomd-dlext` CUDA 12 migration to generate a new migration PR.

xref: https://github.com/conda-forge/hoomd-dlext-feedstock/pull/8