### PR TITLE
Reset the version PR info of OpenMM-Torch

### DIFF
--- a/version_pr_info/e/2/4/6/b/openmm-torch.json
+++ b/version_pr_info/e/2/4/6/b/openmm-torch.json
@@ -1,11 +1,5 @@
 {
  "bad": false,
- "new_version": "03",
- "new_version_attempts": {
-  "0.2": 1,
-  "03": 35
- },
- "new_version_errors": {
-  "03": "The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '03' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/openmm/{{ name }}/archive/v{{ version }}.tar.gz'\n"
- }
+ "new_version_attempts": {},
+ "new_version_errors": {}
 }


### PR DESCRIPTION
The upstream of OpenMM-Torch (https://github.com/openmm/openmm-torch) had a typo in a tag (`v.03` rather than `v0.3`).

This resulted in broken version builds:
https://conda-forge.org/status/ reports:
```
35.00 attempts - The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!

Please check the URLs in your recipe with version '03' to make sure they exist!

We also found the following errors:

 - could not hash URL template 'https://github.com/openmm/{{ name }}/archive/v{{ version }}.tar.gz'
```
https://github.com/regro/cf-graph-countyfair/blob/2ffa37b3834e0a0c1dccca9d4610777b7e917b2b/version_pr_info/e/2/4/6/b/openmm-torch.json#L1-L11


After fixing the tag, the issue persists and the new versions aren't built even though the new versions are detected:

https://github.com/regro/cf-graph-countyfair/blob/d069ab81d5de80abf1df53fb4467433be50dd4b0/versions/e/2/4/6/b/openmm-torch.json#L1-L3

This PR resets the version PR info to resume the version builds.