### PR TITLE
Clear xgboost arch migrators status again

### DIFF
--- a/pr_info/8/6/f/7/5/xgboost.json
+++ b/pr_info/8/6/f/7/5/xgboost.json
@@ -723,11 +723,7 @@
  ],
  "bad": false,
  "pinning_version": "2023.10.10.09.57.53",
- "pre_pr_migrator_attempts": {
-  "armosxaddition": 10
- },
- "pre_pr_migrator_status": {
-  "armosxaddition": "bot error (<a href=\"https://github.com/regro/cf-scripts/actions/runs/6551043640\">bot CI job</a>): main: Traceback (most recent call last):\n  File \"/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/auto_tick.py\", line 1270, in _run_migrator\n    migrator_uid, pr_json = run(\n  File \"/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/auto_tick.py\", line 292, in run\n    eval_cmd(\n  File \"/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/os_utils.py\", line 36, in eval_cmd\n    c.check_returncode()\n  File \"/home/runner/micromamba/envs/cf-scripts/lib/python3.10/subprocess.py\", line 457, in check_returncode\n    raise CalledProcessError(self.returncode, self.args, self.stdout,\nsubprocess.CalledProcessError: Command 'conda smithy rerender -c auto --no-check-uptodate' returned non-zero exit status 1.\n"
- },
+ "pre_pr_migrator_attempts": {},
+ "pre_pr_migrator_status": {},
  "smithy_version": "3.27.1"
 }


### PR DESCRIPTION
The macOS ARM migrator is already applied. However the bot shows an error. We tried to clear this before, but the bot still ran into issues with the recipe format. Have made a formatting change, which may help (however was unable to reproduce the bot issue so couldn't test). Clearing the status here to try again and see if it is fixed.

xref: https://github.com/regro/cf-graph-countyfair/pull/8 (where this was originally tried)