### PR TITLE
Clear CUDA 12 status of `seekr2_openmm_plugin`

### DIFF
--- a/pr_info/8/6/d/b/3/seekr2_openmm_plugin.json
+++ b/pr_info/8/6/d/b/3/seekr2_openmm_plugin.json
@@ -163,25 +163,6 @@
   },
   {
    "PR": {
-    "__lazy_json__": "pr_json/1630906960.json"
-   },
-   "data": {
-    "bot_rerun": false,
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 3,
-    "migrator_version": 0,
-    "name": "cuda120"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
-   ]
-  },
-  {
-   "PR": {
     "__lazy_json__": "pr_json/1630908168.json"
    },
    "data": {


### PR DESCRIPTION
The migration bot said it would re-run this. However it appears that it marked it done instead. However `seekr2_openmm_plugin` is not done for CUDA 12. Trying to clear out the CUDA 12 status of `seekr2_openmm_plugin` to prompt the bot to make a fresh CUDA 12 PR.

xref: https://github.com/conda-forge/seekr2_openmm_plugin-feedstock/pull/15