### PR TITLE
versions: reset onednn latest version to 3.3

### DIFF
--- a/versions/8/f/1/9/b/onednn.json
+++ b/versions/8/f/1/9/b/onednn.json
@@ -1,3 +1,3 @@
 {
- "new_version": "3.3.4"
+ "new_version": "3.3"
 }


### PR DESCRIPTION
This is to add the latest onednn versions that were skipped due to the following issue: https://github.com/regro/cf-scripts/pull/1991
Currently the latest version in conda-forge is 3.3 but should be 3.3.4: https://anaconda.org/conda-forge/onednn/files 