### PR TITLE
Remove broken pyscal_dev::pyscal package

### DIFF
--- a/node_attrs/4/d/1/c/6/pyscal_dev::pyscal.json
+++ b/node_attrs/4/d/1/c/6/pyscal_dev::pyscal.json
@@ -1,9 +1,0 @@
-{
- "parsing_error": "make_graph: missing parsing_error key",
- "pr_info": {
-  "__lazy_json__": "pr_info/pyscal_dev::pyscal.json"
- },
- "version_pr_info": {
-  "__lazy_json__": "version_pr_info/pyscal_dev::pyscal.json"
- }
-}

--- a/node_attrs/conda-forge/label/4/d/1/c/6/pyscal_dev::pyscal.json
+++ b/node_attrs/conda-forge/label/4/d/1/c/6/pyscal_dev::pyscal.json
@@ -1,5 +1,0 @@
-{
- "archived": true,
- "bad": false,
- "feedstock_name": "conda-forge/label/pyscal_dev::pyscal"
-}

--- a/pr_info/4/d/1/c/6/pyscal_dev::pyscal.json
+++ b/pr_info/4/d/1/c/6/pyscal_dev::pyscal.json
@@ -1,4 +1,0 @@
-{
- "pre_pr_migrator_attempts": {},
- "pre_pr_migrator_status": {}
-}

--- a/version_pr_info/4/d/1/c/6/pyscal_dev::pyscal.json
+++ b/version_pr_info/4/d/1/c/6/pyscal_dev::pyscal.json
@@ -1,4 +1,0 @@
-{
- "new_version_attempts": {},
- "new_version_errors": {}
-}


### PR DESCRIPTION
This package
- has an invalid feedstock name
- has a node_attrs file that is almost empty but no parsing_error is specified
- was not present in the graph at all (only in the payload section but not as a node)

It should be deleted.