### PR TITLE
Reset `cuda-python` in `python312` migrator

### DIFF
--- a/pr_info/3/b/e/c/5/cuda-python.json
+++ b/pr_info/3/b/e/c/5/cuda-python.json
@@ -480,27 +480,6 @@
   },
   {
    "PR": {
-    "labels": [],
-    "number": 42,
-    "state": "closed"
-   },
-   "data": {
-    "bot_rerun": false,
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 1,
-    "migrator_version": 0,
-    "name": "python312"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
-   ]
-  },
-  {
-   "PR": {
     "labels": [
      {
       "name": "bot-rerun"
@@ -556,33 +535,6 @@
       "name": "bot-rerun"
      }
     ],
-    "number": 51,
-    "state": "closed"
-   },
-   "data": {
-    "bot_rerun": 1698174032.3589401,
-    "branch": "11.8",
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 1,
-    "migrator_version": 0,
-    "name": "python312"
-   },
-   "keys": [
-    "bot_rerun",
-    "branch",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
-   ]
-  },
-  {
-   "PR": {
-    "labels": [
-     {
-      "name": "bot-rerun"
-     }
-    ],
     "number": 52,
     "state": "closed"
    },
@@ -593,29 +545,6 @@
     "migrator_object_version": 1,
     "migrator_version": 0,
     "name": "cuda118"
-   },
-   "keys": [
-    "bot_rerun",
-    "branch",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
-   ]
-  },
-  {
-   "PR": {
-    "labels": [],
-    "number": null,
-    "state": "closed"
-   },
-   "data": {
-    "bot_rerun": false,
-    "branch": "11.8",
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 1,
-    "migrator_version": 0,
-    "name": "python312"
    },
    "keys": [
     "bot_rerun",


### PR DESCRIPTION
A bot rerun was requested for `cuda-python`'s `11.8` branch for the `python312` migrator ( https://github.com/conda-forge/cuda-python-feedstock/pull/51 ). However the bot never reissued the `python312` migrator PR

To address, this PR clears the `python312` migrator status from `cuda-python` so that the bot can try again