### PR TITLE
fix: make total status ok for model failures

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,6 +64,7 @@ jobs:
 
   tests-model:
     name: tests-model
+    continue-on-error: true
     runs-on: "ubuntu-latest"
     defaults:
       run:


### PR DESCRIPTION
This PR tries to make the overall status green but still show model failures in CI jobs.