### PR TITLE
Reset `hdbscan` in `numpy2` migrator

### DIFF
--- a/pr_info/c/9/4/0/f/hdbscan.json
+++ b/pr_info/c/9/4/0/f/hdbscan.json
@@ -632,31 +632,6 @@
   },
   {
    "PR": {
-    "labels": [
-     {
-      "name": "bot-rerun"
-     }
-    ],
-    "number": 64,
-    "state": "closed"
-   },
-   "data": {
-    "bot_rerun": 1716598429.9490588,
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 1,
-    "migrator_version": 0,
-    "name": "numpy2"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
-   ]
-  },
-  {
-   "PR": {
     "labels": [],
     "number": 65,
     "state": "closed"
@@ -676,31 +651,6 @@
   },
   {
    "PR": {
-    "labels": [
-     {
-      "name": "bot-rerun"
-     }
-    ],
-    "number": 66,
-    "state": "closed"
-   },
-   "data": {
-    "bot_rerun": 1720081829.444992,
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 1,
-    "migrator_version": 0,
-    "name": "numpy2"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
-   ]
-  },
-  {
-   "PR": {
     "labels": [],
     "number": 69,
     "state": "closed"
@@ -716,27 +666,6 @@
     "migrator_name",
     "migrator_version",
     "version"
-   ]
-  },
-  {
-   "PR": {
-    "labels": [],
-    "number": null,
-    "state": "closed"
-   },
-   "data": {
-    "bot_rerun": false,
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 1,
-    "migrator_version": 0,
-    "name": "numpy2"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
    ]
   },
   {


### PR DESCRIPTION
Recently the bot close the NumPy 2 migration for `hdbscan`: https://github.com/conda-forge/hdbscan-feedstock/pull/64

However as the work wasn't actually done to migrate the feedstock, the bot should have started a new migrator. Instead the bot marked it done

This clears out the NumPy 2 migration status for `hdbscan` so it can get a fresh migrator PR