### PR TITLE
Reset version pr info for openml

### DIFF
--- a/version_pr_info/2/a/c/0/d/openml.json
+++ b/version_pr_info/2/a/c/0/d/openml.json
@@ -1,10 +1,5 @@
 {
  "bad": false,
- "new_version": "31_36",
- "new_version_attempts": {
-  "31_36": 156
- },
- "new_version_errors": {
-  "31_36": "bot error (<a href=\"https://github.com/regro/cf-scripts/actions/runs/10299066648\">bot CI job</a>): main:\nError running migrate-feedstock in container - error VersionMigrationError raised:\n\"The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '31_36' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/openml-{{ version }}.tar.gz'\n\""
- }
+ "new_version_attempts": {},
+ "new_version_errors": {}
 }


### PR DESCRIPTION
I am attacking our errored version migrator backlog, where `openml` is the one with the most failed attempts. This is due to a bad version that made its way into the version pr info, which this PR resets.