### PR TITLE
Revert `pypy38` closing so it can get paused again

### DIFF
--- a/status/closed_status.json
+++ b/status/closed_status.json
@@ -17,7 +17,6 @@
   "libthrift0190": "libthrift0190 closed at 2024-08-13 07:23:08 UTC",
   "poppler2407": "poppler2407 closed at 2024-08-13 12:45:36 UTC",
   "proj_loosen_pin": "proj_loosen_pin closed at 2024-08-03 16:57:00 UTC",
-  "pypy38": "pypy38 closed at 2024-08-14 10:45:04 UTC",
   "s2n1419": "s2n1419 closed at 2024-08-09 16:17:33 UTC",
   "s2n150": "s2n150 closed at 2024-08-13 12:45:36 UTC",
   "starlink_ast9211": "starlink_ast9211 closed at 2024-08-02 06:23:55 UTC",

--- a/status/longterm_status.json
+++ b/status/longterm_status.json
@@ -1,6 +1,7 @@
 {
   "aarch64andppc64leaddition": "aarch64 and ppc64le addition Migration Status",
   "armosxaddition": "arm osx addition Migration Status",
+  "pypy38": "pypy38 Migration Status",
   "python312": "python312 Migration Status",
   "r-base44_and_m2w64-ucrt": "r-base44_and_m2w64-ucrt Migration Status"
 }

--- a/status/total_status.json
+++ b/status/total_status.json
@@ -22,6 +22,7 @@
   "openmpi5": "openmpi5 Migration Status",
   "openvino202430": "openvino202430 Migration Status",
   "poppler2408": "poppler2408 Migration Status",
+  "pypy38": "pypy38 Migration Status",
   "python312": "python312 Migration Status",
   "r-base44_and_m2w64-ucrt": "r-base44_and_m2w64-ucrt Migration Status",
   "rdma_core53": "rdma_core53 Migration Status",


### PR DESCRIPTION
Partial revert of https://github.com/regro/cf-graph-countyfair/commit/4edcdc4c51320d3410806529da2ff1a8d6606b27 so we can let https://github.com/regro/cf-scripts/pull/2932 do its job.

cc @beckermr 