### PR TITLE
Reset `pytables` in `numpy2` migrator

### DIFF
--- a/pr_info/0/0/1/f/b/pytables.json
+++ b/pr_info/0/0/1/f/b/pytables.json
@@ -673,31 +673,6 @@
   },
   {
    "PR": {
-    "labels": [
-     {
-      "name": "bot-rerun"
-     }
-    ],
-    "number": 100,
-    "state": "closed"
-   },
-   "data": {
-    "bot_rerun": 1723643612.0530338,
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 1,
-    "migrator_version": 0,
-    "name": "numpy2"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
-   ]
-  },
-  {
-   "PR": {
     "labels": [],
     "number": 101,
     "state": "closed"
@@ -738,27 +713,6 @@
     "migrator_name",
     "migrator_version",
     "version"
-   ]
-  },
-  {
-   "PR": {
-    "labels": [],
-    "number": null,
-    "state": "closed"
-   },
-   "data": {
-    "bot_rerun": false,
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 1,
-    "migrator_version": 0,
-    "name": "numpy2"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
    ]
   },
   {


### PR DESCRIPTION
Recently the bot close the NumPy 2 migration for `pytables`: https://github.com/conda-forge/pytables-feedstock/pull/100

A bot re-run was requested. However the bot marked it done instead of creating a new migrator

This clears out the NumPy 2 migration status for `pytables` so it can get a fresh migrator PR