### PR TITLE
fix: ensure label in pr data

### DIFF
--- a/pr_info/2/7/e/0/9/windfreak.json
+++ b/pr_info/2/7/e/0/9/windfreak.json
@@ -2,7 +2,7 @@
  "PRed": [
   {
    "PR": {
-    "labels": [],
+    "labels": [{"name": "bot-rerun"}],
     "number": 1,
     "state": "closed"
    },


### PR DESCRIPTION
This happened because I added and then removed a label when working on events w/ PR https://github.com/conda-forge/windfreak-feedstock/pull/1