### PR TITLE
remove spurious tag from torchdata

### DIFF
--- a/version_pr_info/a/2/8/c/4/torchdata.json
+++ b/version_pr_info/a/2/8/c/4/torchdata.json
@@ -1,6 +1,6 @@
 {
  "bad": false,
- "new_version": "1217",
+ "new_version": "0.7.1",
  "new_version_attempts": {
   "0.4.0": 1,
   "0.4.1": 7,
@@ -9,10 +9,7 @@
   "0.6.0": 4,
   "0.6.1": 6,
   "0.7.0": 2,
-  "0.7.1": 1,
-  "1217": 207
+  "0.7.1": 1
  },
- "new_version_errors": {
-  "1217": "bot error (<a href=\"https://github.com/regro/cf-scripts/actions/runs/13474976783\">bot CI job</a>): main:\nTraceback (most recent call last):\n  File \"/opt/autotick-bot/conda_forge_tick/container_cli.py\", line 119, in _run_bot_task\n    data = func(attrs=attrs, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/autotick-bot/conda_forge_tick/container_cli.py\", line 225, in _migrate_feedstock\n    data = run_migration_local(\n           ^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/autotick-bot/conda_forge_tick/migration_runner.py\", line 251, in run_migration_local\n    data[\"migrate_return_value\"] = migrator.migrate(\n                                   ^^^^^^^^^^^^^^^^^\n  File \"/opt/autotick-bot/conda_forge_tick/migrators/version.py\", line 254, in migrate\n    raise VersionMigrationError(\nconda_forge_tick.migrators.version.VersionMigrationError: The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!\n\nPlease check the URLs in your recipe with version '1217' to make sure they exist!\n\nWe also found the following errors:\n\n - could not hash URL template 'https://github.com/pytorch/data/archive/refs/tags/v{{ version }}.tar.gz'\n\n"
- }
+ "new_version_errors": {}
 }


### PR DESCRIPTION
This tag permanently broke the update bot, even though it has been deleted upstream in the meantime.

![image](https://github.com/user-attachments/assets/259a438a-d6e6-4323-aeb2-69369d3259a7)
